### PR TITLE
Fix & improve Rise and Fall Time measurement

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -13,18 +13,23 @@ def rms(data: AnalogSpan):
     rms = math.sqrt(sum_of_squares / len(data))
     return rms
 
+
 def histogram_mode(data: AnalogSpan, filter):
     hist, bins = data.histogram()
-    _count, index = max((count, index) for index, count in enumerate(hist) if filter((bins[index] + bins[index + 1]) / 2))
+    _count, index = max((count, index) for index, count in enumerate(
+        hist) if filter((bins[index] + bins[index + 1]) / 2))
     return (bins[index] + bins[index + 1]) / 2
+
 
 # High & Low can be computed several different ways. If this is False, the "mode" method will be used
 use_histogram_for_mode = True
+
 
 def compute_high(data: AnalogSpan, mid: float):
     if use_histogram_for_mode:
         return histogram_mode(data, lambda x: x >= mid)
     return mode(x for x in data if x >= mid)
+
 
 def compute_low(data: AnalogSpan, mid: float):
     if use_histogram_for_mode:

--- a/measurements.py
+++ b/measurements.py
@@ -6,6 +6,7 @@ from saleae.data import AnalogSpan, GraphTimeDelta
 from saleae.measurements import (AnalogMeasurer, Annotation, HorizontalRule,
                                  Measure, VerticalRule)
 
+CLIPPED_ERROR = 'Clipped'
 
 def rms(data: AnalogSpan):
     # TODO: numpy accelerate
@@ -62,6 +63,18 @@ class VoltageMeasurer(AnalogMeasurer):
     base_annotation = Annotation(measures=[base, amplitude])
 
     def measure_range(self, data: AnalogSpan):
+        if data.clipped:
+            self.peak_to_peak.error = CLIPPED_ERROR
+            self.minimum.error = CLIPPED_ERROR
+            self.maximum.error = CLIPPED_ERROR
+            self.mean.error = CLIPPED_ERROR
+            self.mid.error = CLIPPED_ERROR
+            self.amplitude.error = CLIPPED_ERROR
+            self.top.error = CLIPPED_ERROR
+            self.base.error = CLIPPED_ERROR
+            self.rms.error = CLIPPED_ERROR
+            return
+
         self.minimum.value = data.min
         self.maximum.value = data.max
         self.peak_to_peak.value = data.max - data.min
@@ -120,6 +133,13 @@ class PulseMeasurer(AnalogMeasurer):
     negative_overshoot_annotation = Annotation(measures=[negative_overshoot])
 
     def measure_range(self, data: AnalogSpan):
+        if data.clipped:
+            self.rise_time.error = CLIPPED_ERROR
+            self.fall_time.error = CLIPPED_ERROR
+            self.positive_overshoot.error = CLIPPED_ERROR
+            self.negative_overshoot.error = CLIPPED_ERROR
+            return
+
         mid = (data.max + data.min) / 2
         high = low = None
 
@@ -316,6 +336,13 @@ class TimeMeasurer(AnalogMeasurer):
         measures=[positive_width, negative_width, positive_duty, negative_duty])
 
     def measure_range(self, data: AnalogSpan):
+        if data.clipped:
+            self.positive_width.error = CLIPPED_ERROR
+            self.negative_width.error = CLIPPED_ERROR
+            self.positive_duty.error = CLIPPED_ERROR
+            self.negative_duty.error = CLIPPED_ERROR
+            self.cycle_rms.error = CLIPPED_ERROR
+
         start_index = int(len(data) / 2)
 
         mid = (data.max + data.min) / 2
@@ -426,8 +453,9 @@ class TimeMeasurer(AnalogMeasurer):
             error_string = "Crossings Not Found"
             self.period.error = error_string
             self.frequency.error = error_string
-            self.positive_width.error = error_string
-            self.negative_width.error = error_string
-            self.positive_duty.error = error_string
-            self.negative_duty.error = error_string
-            self.cycle_rms.error = error_string
+            if not data.clipped:
+                self.positive_width.error = error_string
+                self.negative_width.error = error_string
+                self.positive_duty.error = error_string
+                self.negative_duty.error = error_string
+                self.cycle_rms.error = error_string


### PR DESCRIPTION
1. The located rise and fall times were nowhere near the center. This now finds the closest edges to the center (and supports where the center point is within an edge)
2. Fixes a bug where the noise would prevent the correct start or edge point from being located. now, once the start end and conditions are located, it will back up and check for another start point that is closer to the end point.